### PR TITLE
Add deterministic cache/replay layer

### DIFF
--- a/execution/cache/README.md
+++ b/execution/cache/README.md
@@ -1,0 +1,31 @@
+# Deterministic cache
+
+## Cache key components
+The cache key is a SHA-256 hash of the canonical JSON encoding of the cache key data,
+which must conform to `execution/cache/cache_key.schema.json`.
+
+Required components:
+- `authority_ledger_hash`: SHA-256 of `control/authority.ledger.json`.
+- `policy_bundle_hash`: SHA-256 of the `policy/` bundle as recorded in the pre-gen capsule.
+- `pre_gen_capsule_hash`: SHA-256 of `control/runtime/pre_gen_capsule.json`.
+- `inputs_manifest_hash`: SHA-256 of `execution/ledger/inputs.manifest.json` (empty string if absent).
+- `phase`: Pipeline phase identifier (GEN/CHECK/REPAIR/PROMOTE).
+- `tool_versions`: Versions that affect outputs (`runner_version`, `generator_version`).
+
+## Stability rules
+- Canonical JSON encoding is UTF-8, sorted keys, and no extra whitespace.
+- No timestamps, UUIDs, or environment-dependent ordering are permitted in cache key data.
+- Cache keys must be computed after Control Kernel admission.
+- Cache hits must still emit OPA decision/explain artifacts and ledger evidence.
+
+## On-disk layout
+```
+execution/cache/<cache_key>/
+  cache.meta.json
+  execution/gen/outputs.json
+  opa/decision.json
+  opa/explain.json
+  opa/bundle.hash
+```
+
+`cache.meta.json` records the cache key data, cached artifacts, and phase artifacts.

--- a/execution/cache/cache_key.schema.json
+++ b/execution/cache/cache_key.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CBIA Builder Cache Key",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "phase",
+    "authority_ledger_hash",
+    "policy_bundle_hash",
+    "pre_gen_capsule_hash",
+    "inputs_manifest_hash",
+    "tool_versions"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string",
+      "enum": ["GEN", "CHECK", "REPAIR", "PROMOTE"]
+    },
+    "authority_ledger_hash": {
+      "type": "string"
+    },
+    "policy_bundle_hash": {
+      "type": "string"
+    },
+    "pre_gen_capsule_hash": {
+      "type": "string"
+    },
+    "inputs_manifest_hash": {
+      "type": "string"
+    },
+    "tool_versions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runner_version", "generator_version"],
+      "properties": {
+        "runner_version": {"type": "string"},
+        "generator_version": {"type": "string"}
+      }
+    }
+  }
+}

--- a/tests/test_cache_replay.py
+++ b/tests/test_cache_replay.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.pipeline_driver import CacheManager, _gen_phase
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _setup_root(tmp_path: Path) -> dict:
+    authority = {
+        "frozen": True,
+        "authority_set": [
+            {"authority_id": "AUTH-1", "hash": {"value": "abc"}, "source": {"locator": "x"}}
+        ],
+    }
+    _write_json(tmp_path / "control" / "authority.ledger.json", authority)
+    (tmp_path / "policy").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "policy" / "assurance.rego").write_text("package assurance", encoding="utf-8")
+    _write_json(tmp_path / "execution" / "ledger" / "inputs.manifest.json", {"inputs": []})
+    capsule = {
+        "schema_version": "0.1.0",
+        "kernel_decision": "ALLOW",
+        "control_state_hash": "state",
+        "policy_bundle_hash": "policyhash",
+        "authority_set_hashes": {"AUTH-1": "abc"},
+    }
+    _write_json(tmp_path / "control" / "runtime" / "pre_gen_capsule.json", capsule)
+    (tmp_path / "opa").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "opa" / "decision.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "opa" / "explain.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "opa" / "bundle.hash").write_text("{}", encoding="utf-8")
+    return capsule
+
+
+def test_cache_hit_replays_identical_outputs(tmp_path: Path) -> None:
+    capsule = _setup_root(tmp_path)
+    cache_manager = CacheManager(str(tmp_path))
+
+    phase_outputs = _gen_phase(capsule, str(tmp_path))
+    key_data = cache_manager.cache_key_data("GEN", capsule)
+    cache_key = cache_manager.cache_key(key_data)
+    cache_manager.store(cache_key, key_data, phase_outputs)
+
+    output_path = Path(phase_outputs[0])
+    original_bytes = output_path.read_bytes()
+    output_path.unlink()
+
+    assert cache_manager.has_cache(cache_key)
+    replayed = cache_manager.replay(cache_key)
+    assert replayed == [str(output_path)]
+    assert output_path.read_bytes() == original_bytes
+
+
+def test_cache_key_changes_on_authority_policy_or_capsule(tmp_path: Path) -> None:
+    capsule = _setup_root(tmp_path)
+    cache_manager = CacheManager(str(tmp_path))
+
+    key_data = cache_manager.cache_key_data("GEN", capsule)
+    base_key = cache_manager.cache_key(key_data)
+
+    authority_path = tmp_path / "control" / "authority.ledger.json"
+    authority_payload = json.loads(authority_path.read_text(encoding="utf-8"))
+    authority_payload["authority_set"].append(
+        {"authority_id": "AUTH-2", "hash": {"value": "def"}, "source": {"locator": "y"}}
+    )
+    _write_json(authority_path, authority_payload)
+    key_after_authority = cache_manager.cache_key(cache_manager.cache_key_data("GEN", capsule))
+    assert base_key != key_after_authority
+
+    policy_path = tmp_path / "policy" / "assurance.rego"
+    policy_path.write_text("package assurance\n# change", encoding="utf-8")
+    key_after_policy = cache_manager.cache_key(cache_manager.cache_key_data("GEN", capsule))
+    assert base_key != key_after_policy
+
+    capsule_path = tmp_path / "control" / "runtime" / "pre_gen_capsule.json"
+    capsule_payload = json.loads(capsule_path.read_text(encoding="utf-8"))
+    capsule_payload["policy_bundle_hash"] = "policyhash2"
+    _write_json(capsule_path, capsule_payload)
+    key_after_capsule = cache_manager.cache_key(cache_manager.cache_key_data("GEN", capsule))
+    assert base_key != key_after_capsule


### PR DESCRIPTION
### Motivation
- Implement a deterministic, content-addressed cache and replay layer so repeated runs with identical admissible inputs can skip regeneration while still emitting full audit evidence.
- Ensure cache keys are computed after Control Kernel admission and include authoritative inputs and tool versions to force misses on input/tool changes.
- Preserve OPA gating and ledger/evidence semantics while enabling deterministic replay of phase outputs.
- Provide a stable on-disk layout and documentation for cache artifacts and meta information.

### Description
- Added `execution/cache/cache_key.schema.json` and `execution/cache/README.md` to define the cache key schema, stability rules, and on-disk layout.
- Extended `tools/pipeline_driver.py` with canonical JSON hashing, runner-version hashing, `_gen_phase`, and a new `CacheManager` class that computes cache keys, stores cache artifacts (including OPA outputs), and replays them deterministically.
- Integrated cache logic into the `PipelineDriver.run` GEN path to check for cache hits, replay or produce GEN outputs, and always append a ledger entry and manifest entry that records cache hit/miss and `cache_key`.
- Parameterized `_inputs_manifest_hash` and `_phase_inputs` to accept a `root` so tests and replay can operate on ephemeral roots, and added deterministic artifact hashing and ledger entry id generation.

### Testing
- Added automated tests at `tests/test_cache_replay.py` which include a `test_cache_hit_replays_identical_outputs` and `test_cache_key_changes_on_authority_policy_or_capsule` to validate replay correctness and cache-key sensitivity to authoritative inputs.
- The new tests and code were added and committed, but the test suite was not executed in this rollout (tests were not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963aa7405f08321b0ab638d0af13d25)