### PR TITLE
control: add math topic index authority + seed

### DIFF
--- a/control/authority/master-math-doc.md
+++ b/control/authority/master-math-doc.md
@@ -1,0 +1,19 @@
+# Master Math Doc (INF1220) {#math.master}
+
+This is a sanitized, anchor-indexed math recall reference used to build `math_topic_index.json`.
+Headings are intentionally short and stable.
+
+## Propositions and truth values {#math.logic.propositions}
+## Logical operators: not, and, or, implication {#math.logic.operators}
+## Truth tables {#math.logic.truth-tables}
+
+## Sets and membership {#math.sets.membership}
+## Set operations: union, intersection, difference {#math.sets.operations}
+
+## Relations (binary relations) {#math.relations.binary}
+## Properties: reflexive, symmetric, transitive, antisymmetric {#math.relations.properties}
+## Equivalence relations {#math.relations.equivalence}
+## Order relations {#math.relations.order}
+
+## Cartesian product and ordered pairs {#math.sets.cartesian-product}
+## Functions as relations {#math.functions.as-relations}

--- a/control/rules/math_topic_index.seed.json
+++ b/control/rules/math_topic_index.seed.json
@@ -1,0 +1,5 @@
+{
+  "version": "v0.1.0",
+  "source": "control/authority/master-math-doc.md",
+  "topics": []
+}


### PR DESCRIPTION
### Motivation
- Make `tools/build_math_topic_index.py` runnable on main by providing a canonical anchored authority document and a minimal seed so the tool can auto-generate the math topic index. 
- Keep the change minimal and dependency-free, with all parsing logic remaining in `/tools` and no policy/OPA additions. 

### Description
- Add `control/authority/master-math-doc.md` containing anchored headings using the exact `## Title {#anchor.id}` syntax consumed by the parser. 
- Add a lean seed file `control/rules/math_topic_index.seed.json` with `version`, `source`, and an empty `topics` array so the build tool auto-populates topics. 
- No new dependencies, frameworks, or policy expansion were introduced and all logic remains in the existing tooling. 

### Testing
- Ran `uv run python tools/build_math_topic_index.py` and the command completed successfully. 
- Verified artifact creation with `test -f control/artifacts/math_topic_index.json` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c13d737a083218f38f6f4118562b7)